### PR TITLE
fixed sorting Clinical Data table by Patient

### DIFF
--- a/src/pages/studyView/tabs/ClinicalDataTab.tsx
+++ b/src/pages/studyView/tabs/ClinicalDataTab.tsx
@@ -157,7 +157,7 @@ export class ClinicalDataTab extends React.Component<
         switch (this.clinicalDataSortCriteria?.field) {
             // these first two are special cases where we are not filtering
             // by an attribute
-            case 'Patient ID':
+            case 'Patient':
                 return 'patientId';
             case 'Sample ID':
                 return 'sampleId';
@@ -218,15 +218,14 @@ export class ClinicalDataTab extends React.Component<
                                 )}
                                 target="_blank"
                             >
-                                {this.format(
-                                    data.PATIENT_DISPLAY_NAME &&
-                                        data.PATIENT_DISPLAY_NAME !== 'Unknown'
-                                        ? data.PATIENT_DISPLAY_NAME +
-                                              ' (' +
-                                              data.patientId +
-                                              ')'
-                                        : data.patientId
-                                )}
+                                {data.PATIENT_DISPLAY_NAME &&
+                                    data.PATIENT_DISPLAY_NAME !== 'Unknown'
+                                    ? this.format(data.PATIENT_DISPLAY_NAME) +
+                                        ' (' +
+                                        data.patientId +
+                                        ')'
+                                    : data.patientId
+                                }
                             </a>
                         );
                     },


### PR DESCRIPTION
# Problem
Es wurde in der neuen Version des Frontends in ClinicalDataTab.tsx eine neue Funktion hinzugefügt, die (wenn ich das richtig verstehe) beim Sortieren prüft, ob in der Tabelle mit den klinischen Attributen ein Eintrag steht oder nicht. Sollte der Eintrag leer sein, dann wird die komplette Zeile beim Sortieren herausgefiltert. Jetzt gab es aber das Problem, dass die Patienten ID nicht in dieser Tabelle steht, sondern in data.patientID. Um das zu lösen, hatte cBioPortal dafür (und auch für sampleID) deswegen eine Exception für die Spalte „Patient ID“ hinzugefügt. In einer früheren Version von buschlab/cbioportal-frontend wurde diese Spalte in „Patient“ umbenannt. Deswegen griff die Exception nicht und die Funktion suchte vergebens in der Tabelle der klinischen Attributen nach „Patient“. Da dort nie etwas stand wurden dann alle Zeilen herausgefiltert.

# Änderungen
- Die Exception wurde geändert („Patient“ statt „Patient ID“).
- Ich habe geändert wie der Anzeigestring unter "Patient" konstruiert wird. patientID sollte eigentlich keine Umlaute enthalten, daher muss nur PATIENT_DISPLAY_NAME reformatiert werden. Das ist allerdings nicht notwendig, damit die Sortierung funktioniert.
